### PR TITLE
Adds hash table memory cleanup function

### DIFF
--- a/ProjectTwo/ProjectTwo.cpp
+++ b/ProjectTwo/ProjectTwo.cpp
@@ -664,6 +664,34 @@ void printPrerequisites(const Course& course, const HashTable& table) {
 }
 
 /**
+ * Function: Clean Up Hash Table
+ * Purpose: Deallocates all memory used by hash table
+ * Input: table - reference to hash table to clean up
+ * Output: Frees all nodes and resets table to empty state
+ */
+void cleanupHashTable(HashTable& table) {
+    // Traverse all buckets in the hash table
+    for (int i = 0; i < table.capacity; i++) {
+        HashNode* current = table.buckets[i];
+
+        // Delete all nodes in the collision chain at this bucket
+        while (current != nullptr) {
+            HashNode* next = current->next;
+            delete current;
+            current = next;
+        }
+
+        // Set bucket pointer to null
+        table.buckets[i] = nullptr;
+    }
+
+    // Reset table properties
+    table.size = 0;
+
+    cout << "Hash table memory cleaned up successfully" << endl;
+}
+
+/**
  * Trims leading/trailing whitespace and quotes from filename
  */
 string trimFilename(const string& filename) {
@@ -901,7 +929,9 @@ int main() {
             menuOption3(courseTable);
         }
         else if (choice == "9") {
-            cout << "Thank you for using the course planner!\n" << endl;
+            cout << "\nCleaning up memory..." << endl;
+            cleanupHashTable(courseTable);
+            cout << "\nThank you for using the course planner!\n" << endl;
             cout << "Press Enter to exit...";
             cin.get(); // Wait for user to press Enter before exiting
             running = false;


### PR DESCRIPTION
Implements a function to deallocate memory used by the hash table. This prevents memory leaks when the program exits.

The cleanup function iterates through each bucket, deletes nodes in collision chains, and resets table properties.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
